### PR TITLE
Use luasnip api for getting choice-docstrings

### DIFF
--- a/lua/cmp_luasnip_choice/init.lua
+++ b/lua/cmp_luasnip_choice/init.lua
@@ -50,23 +50,21 @@ function M.source:get_keyword_pattern()
     return ''
 end
 
-function M.source:complete(params, callback)
+function M.source:complete(_, callback)
     local items = {}
-    local choices = require('luasnip.session').active_choice_node.choices
-    for _, choice in ipairs(choices) do
-        local copy = choice:copy()
-        copy:static_init()
 
-        local text = ''
-        for _, str in ipairs(copy:get_static_text()) do
-            text = text .. str .. '\n'
-        end
+    local choices_ok, choice_docstrings = pcall(require('luasnip').get_current_choices)
+    if not choices_ok then
+        -- no choice active: return no completion-items.
+        callback(items)
+    end
 
+    for _, choice_docstring in ipairs(choice_docstrings) do
         table.insert(items, {
-            label = copy:get_static_text()[1],
-            word = copy:get_static_text()[1],
+            label = choice_docstring,
+            word = choice_docstring,
             index = _,
-            documentation = text,
+            documentation = choice_docstring,
             kind = cmp.lsp.CompletionItemKind.Snippet,
         })
     end

--- a/lua/cmp_luasnip_choice/init.lua
+++ b/lua/cmp_luasnip_choice/init.lua
@@ -62,7 +62,7 @@ function M.source:complete(_, callback)
     for _, choice_docstring in ipairs(choice_docstrings) do
         table.insert(items, {
             label = choice_docstring,
-            word = choice_docstring,
+            word = "",
             index = _,
             documentation = choice_docstring,
             kind = cmp.lsp.CompletionItemKind.Snippet,


### PR DESCRIPTION
Hey!
I noticed (due to [an issue in luasnip](https://github.com/L3MON4D3/LuaSnip/issues/805)) that first of all, this plugin exists, nice work! and that it's using some not-so-safe api of luasnip.

This change mostly uses `ls.get_current_choices` to get the string-descriptions of the choices, which should be more stable than the current approach.

Also, I've set the text inserted by nvim-cmp when hovering over any of the choices to `""`, I've encountered some issues when this was long text (for example with [this](https://github.com/L3MON4D3/Dotfiles/blob/9cc98b1c2c3331786ba317310d2e0d181a1aeb58/.config/nvim/luasnippets/.lua#L159-L189) snippet) (feel free to have me drop this one if you don't like it though :) )